### PR TITLE
Add Seerr support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Media Cleaner
 
-Media Cleaner is a simple CLI tool to clean up your media library based on your Overseerr requests and Tautulli history, written in Rust.
+Media Cleaner is a simple CLI tool to clean up your media library based on your Overseerr/Seerr requests and Tautulli history, written in Rust.
 
 It was written to help me clean up my Plex library, but it should work for anyone with a similar setup. It's not perfect, but it works for me. (This project was written partly to help me learn Rust, so please don't judge me too harshly, though feedback is always welcome.)
 
@@ -22,7 +22,7 @@ items_shown: 5
 plex:
     url: https://YOUR_PLEX_URL
     token: YOUR_PLEX_TOKEN
-overseerr:
+overseerr: # You can also use "seerr:" here if you've migrated to Seerr
     url: https://YOUR_OVERSEERR_URL
     api_key: YOUR_API_KEY
 tautulli:
@@ -46,11 +46,11 @@ All fields have to be filled in, except for Sonarr or Radarr (though if their ro
 
 You can get your api keys from the respective applications. A simple search should help you find it. For the Plex token, you can follow [this guide](https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/).
 
-**ALSO MAKE SURE CSRF IS TURNED OFF IN OVERSEERR.**
+**ALSO MAKE SURE CSRF IS TURNED OFF IN OVERSEERR/SEERR.**
 
 #### Ignoring users
 
-If you want to ignore a user (or multiple) simply add them to the `ignored_users` list in the config file. This is useful if you have a user that you don't want to remove media for, for example yourself. The user is matched by their Overseerr username, so make sure you use the same username in both places.
+If you want to ignore a user (or multiple) simply add them to the `ignored_users` list in the config file. This is useful if you have a user that you don't want to remove media for, for example yourself. The user is matched by their Overseerr/Seerr username, so make sure you use the same username in both places.
 
 Example:
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,7 +9,8 @@ pub struct Config {
     #[serde(default = "default_items_shown")]
     pub items_shown: usize,
     pub plex: Plex,
-    pub overseerr: Overseerr,
+    #[serde(alias = "overseerr")]
+    pub seerr: Seerr,
     pub tautulli: Tautulli,
     pub sonarr: Option<Sonarr>,
     pub sonarr_4k: Option<Sonarr>,
@@ -25,7 +26,7 @@ pub struct Plex {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct Overseerr {
+pub struct Seerr {
     pub url: String,
     pub api_key: String,
 }
@@ -70,7 +71,7 @@ impl Config {
     }
 
     fn clean_urls(conf: &mut Config) {
-        clean_url(&mut conf.overseerr.url);
+        clean_url(&mut conf.seerr.url);
         clean_url(&mut conf.plex.url);
         clean_url(&mut conf.tautulli.url);
 

--- a/src/overseerr/api.rs
+++ b/src/overseerr/api.rs
@@ -12,7 +12,7 @@ where
     T: DeserializeOwned,
 {
     let client = reqwest::Client::new();
-    let config = &Config::global().overseerr;
+    let config = &Config::global().seerr;
     let response = client
         .get(format!(
             "{}/api/v1{}?take=100&{}",
@@ -54,7 +54,7 @@ where
 }
 
 pub async fn delete(path: &str) -> Result<()> {
-    let config = &Config::global().overseerr;
+    let config = &Config::global().seerr;
     let client = reqwest::Client::new();
 
     client

--- a/src/overseerr/responses.rs
+++ b/src/overseerr/responses.rs
@@ -50,6 +50,8 @@ pub enum MediaStatus {
     Processing,
     PartiallyAvailable,
     Available,
+    Blocklisted,
+    Deleted,
 }
 
 impl Display for MediaStatus {
@@ -60,6 +62,8 @@ impl Display for MediaStatus {
             Self::Processing => write!(f, "{}", "Processing".yellow().to_string()),
             Self::PartiallyAvailable => write!(f, "{}", "Partially Available".blue().to_string()),
             Self::Available => write!(f, "{}", "Available".green().to_string()),
+            Self::Blocklisted => write!(f, "{}", "Blocklisted".red().to_string()),
+            Self::Deleted => write!(f, "{}", "Deleted".red().to_string()),
         }
     }
 }


### PR DESCRIPTION
## Summary

Seerr (the unified Overseerr + Jellyseerr successor) added two new MediaStatus values, Blocklisted (6) and Deleted (7), which caused a deserialization crash.

- Add missing Blocklisted and Deleted variants to the MediaStatus enum
- Accept either `seerr` or `overseerr` as the config key so existing setups keep working